### PR TITLE
fix: preserve random_seed across applies

### DIFF
--- a/azurecaf/internal/schemas/base.go
+++ b/azurecaf/internal/schemas/base.go
@@ -498,7 +498,8 @@ func BaseSchema() map[string]*schema.Schema {
 		"random_seed": {
 			Type:     schema.TypeInt,
 			Optional: true,
-			ValidateFunc: validation.IntAtLeast(1),
+			Computed: true,
+			ForceNew: true,
 		},
 		"use_slug": {
 			Type:     schema.TypeBool,

--- a/azurecaf/resource_name.go
+++ b/azurecaf/resource_name.go
@@ -88,6 +88,13 @@ func getDifference(context context.Context, d *schema.ResourceDiff, resource int
 			return fmt.Errorf("failed to set random_string: %v", err)
 		}
 	}
+	
+	// Preserve non-zero random_seed in state
+	if randomSeed != 0 {
+		if err := d.SetNew("random_seed", randomSeed); err != nil {
+			return fmt.Errorf("failed to preserve random_seed: %v", err)
+		}
+	}
 	namePrecedence := []string{"name", "slug", "random", "suffixes", "prefixes"}
 	result, err := getResourceName(resourceType, separator, prefixes, name, suffixes, randomSuffix, cleanInput, passthrough, useSlug, namePrecedence)
 	if err != nil {


### PR DESCRIPTION
- Add Computed and ForceNew attributes to random_seed schema
- Ensure random_seed is preserved in getDifference function
- Fix unwanted in-place updates caused by random_seed becoming null

# [Issue-id](https://github.com/aztfmod/terraform-provider-azurecaf/issues/ISSUE-ID-GOES-HERE)

## PR Checklist

---

<!-- Use the check list below to ensure your branch is ready for PR. -->

- [ ] I have read the [CONTRIBUTING.MD instructions](./CONTRIBUTING.md)
- [ ] I have changed the `resourceDefinition.json`
- [ ] I have generated the resource model (there's a ```models_generated.go``` file in my PR)
- [ ] I have updated the [README.md#resource-status](../README.md)
- [ ] I have checked to ensure there aren't other open Pull Requests for the same update/change?

## Description

<!-- Concise description of the problem and the solution or the feature being added -->

## Does this introduce a breaking change

- [ ] YES
- [ ] NO

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Testing

<!-- Instructions for testing and validation of your code -->
